### PR TITLE
profile页面title不设置layout_centerInParent=center。防止过长的英文node名字被title遮挡

### DIFF
--- a/app/src/main/res/layout/fav_item.xml
+++ b/app/src/main/res/layout/fav_item.xml
@@ -16,7 +16,6 @@
 
     <TextView
         android:id="@+id/tv_title"
-        android:layout_centerInParent="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toRightOf="@+id/tv_node"


### PR DESCRIPTION
（测试机：小米1S，MIUI v5, android:4.1.2）
